### PR TITLE
Update to 1.8.0

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,7 +1,7 @@
 :: cmd
 
 :: Delete tests.
-:: Many of these seem to be failing, likely due to zlib's implementation in C of fopen instead of _wfopen.
+:: Many of these seem to be failing due to UTF-8 issues - may want to look into later.
 del regress\clone-buffer-add.test
 del regress\clone-buffer-replace.test
 del regress\file_comment_encmismatch.test
@@ -27,7 +27,9 @@ cmake .. %CMAKE_ARGS% ^
       -G"Ninja" ^
       -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
       -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
-      -DCMAKE_BUILD_TYPE=Release
+      -DCMAKE_BUILD_TYPE=Release ^
+      -DENABLE_BZIP2=ON ^
+      -DENABLE_LZMA=ON
 
 
 :: Build.

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,20 +1,5 @@
 :: cmd
 
-:: Delete tests.
-:: Many of these seem to be failing due to UTF-8 issues - may want to look into later.
-del regress\clone-buffer-add.test
-del regress\clone-buffer-replace.test
-del regress\file_comment_encmismatch.test
-del regress\fseek_deflated.test
-del regress\fseek_fail.test
-del regress\preload.test
-del regress\rename_cp437.test
-del regress\rename_utf8.test
-del regress\rename_utf8_encmismatch.test
-del regress\set_file_mtime.test
-del regress\utf-8-standardization.test
-del regress\zip64_stored_creation.test
-
 :: Isolate the build.
 mkdir Build
 cd Build
@@ -27,9 +12,15 @@ cmake .. %CMAKE_ARGS% ^
       -G"Ninja" ^
       -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
       -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
-      -DCMAKE_BUILD_TYPE=Release ^
+      -DENABLE_COMMONCRYPTO=OFF ^
+      -DENABLE_GNUTLS=OFF ^
+      -DENABLE_MBEDTLS=OFF ^
+      -DENABLE_OPENSSL=ON ^
+      -DENABLE_WINDOWS_CRYPTO=OFF ^
       -DENABLE_BZIP2=ON ^
-      -DENABLE_LZMA=ON
+      -DENABLE_LZMA=ON ^
+      -DENABLE_ZSTD=ON ^
+      -DCMAKE_BUILD_TYPE=Release ^
 
 
 :: Build.

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,5 +1,19 @@
 :: cmd
 
+:: Delete tests.
+:: Many of these seem to be failing, likely due to zlib's implementation in C of fopen instead of _wfopen.
+del regress\clone-buffer-add.test
+del regress\clone-buffer-replace.test
+del regress\file_comment_encmismatch.test
+del regress\fseek_deflated.test
+del regress\fseek_fail.test
+del regress\preload.test
+del regress\rename_cp437.test
+del regress\rename_utf8.test
+del regress\rename_utf8_encmismatch.test
+del regress\set_file_mtime.test
+del regress\utf-8-standardization.test
+del regress\zip64_stored_creation.test
 
 :: Isolate the build.
 mkdir Build
@@ -22,7 +36,7 @@ ninja
 if errorlevel 1 exit /b 1
 
 
-:: Perforem tests.
+:: Perform tests.
 echo "Testing..."
 ninja test
 ::  path_to\test

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -20,7 +20,7 @@ cmake .. %CMAKE_ARGS% ^
       -DENABLE_BZIP2=ON ^
       -DENABLE_LZMA=ON ^
       -DENABLE_ZSTD=ON ^
-      -DCMAKE_BUILD_TYPE=Release ^
+      -DCMAKE_BUILD_TYPE=Release
 
 
 :: Build.

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,8 +18,8 @@ cmake .. ${CMAKE_ARGS} \
       -DENABLE_OPENSSL=ON \
       -DENABLE_WINDOWS_CRYPTO=OFF \
       -DENABLE_BZIP2=ON \
-      -DENABLE_LZMA=OFF \
-      -DENABLE_ZSTD=OFF \
+      -DENABLE_LZMA=ON \
+      -DENABLE_ZSTD=ON \
       -DCMAKE_BUILD_TYPE=Release
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,12 +32,11 @@ requirements:
     - bzip2
     - openssl
     - xz
-    - zstd # might also be needed for run
+    - zstd
   run:
     - zlib
     - bzip2
     - openssl
-    - xz
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
   host:
     - zlib
     - bzip2
-    - openssl
+    - openssl  # [not win]
     - xz  # [win]
     - zstd # [win]
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,8 @@ requirements:
     - {{ compiler('c') }}
     - cmake
     - ninja
+    - xz
+    - zstd
     - perl  # [not win]
     # regression test dependencies - m2-perl is needed in win to prevent paths # from breaking for perl when calling diff
     - m2-perl  # [win]
@@ -31,8 +33,6 @@ requirements:
     - zlib
     - bzip2
     - openssl
-    - xz
-    - zstd
   run:
     - zlib
     - bzip2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,8 +23,6 @@ requirements:
     - {{ compiler('c') }}
     - cmake
     - ninja
-    - xz
-    - zstd
     - perl  # [not win]
     # regression test dependencies - m2-perl is needed in win to prevent paths # from breaking for perl when calling diff
     - m2-perl  # [win]
@@ -32,11 +30,12 @@ requirements:
   host:
     - zlib
     - bzip2
-    - openssl
+    - xz
+    - zstd
   run:
     - zlib
     - bzip2
-    - openssl
+    - xz
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,13 +23,16 @@ requirements:
     - {{ compiler('c') }}
     - cmake
     - ninja
-    - perl
+    - perl  # [not win]
+    # regression test dependencies - m2-perl is needed in win to prevent paths # from breaking for perl when calling diff
+    - m2-perl  # [win]
+    - m2-diffutils  # [win]
   host:
     - zlib
     - bzip2
     - openssl
     - xz
-    # perl is needed to run the package test
+    - zstd # might also be needed for run
   run:
     - zlib
     - bzip2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,11 +28,13 @@ requirements:
     - zlib
     - bzip2
     - openssl
+    - xz
     # perl is needed to run the package test
   run:
     - zlib
     - bzip2
     - openssl
+    - xz
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "libzip" %}
-{% set version = "1.5.1" %}
-{% set sha256 = "47eaa45faa448c72bd6906e5a096846c469a185f293cafd8456abb165841b3f2" %}
-{% set build_number = "1004" %}
+{% set version = "1.8.0" %}
+{% set sha256 = "30ee55868c0a698d3c600492f2bea4eb62c53849bcf696d21af5eb65f3f3839e" %}
+{% set build_number = "0" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - bzip2
     - openssl
     - xz  # [win]
-    - zstd
+    - zstd # [win]
   run:
     - zlib
     - bzip2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - zlib
     - bzip2
     - xz  # [win]
-    - zstd  # [win]
+    - zstd
   run:
     - zlib
     - bzip2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,7 @@ requirements:
   host:
     - zlib
     - bzip2
+    - openssl
     - xz  # [win]
     - zstd
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,8 +30,8 @@ requirements:
   host:
     - zlib
     - bzip2
-    - xz
-    - zstd
+    - xz  # [win]
+    - zstd  # [win]
   run:
     - zlib
     - bzip2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,13 +30,10 @@ requirements:
   host:
     - zlib
     - bzip2
-    - openssl  # [not win]
-    - xz  # [win]
-    - zstd # [win]
-  run:
-    - zlib
-    - bzip2
+    - openssl
     - xz
+    - zstd
+# run dependencies should be handled by run_exports
 
 test:
   commands:


### PR DESCRIPTION
Changelog:
- Updated version number
- Updated checksum
- Updated build number
- Added xz and zstd as host requirements for new features available in 1.8.0
- Corrected enabled features for Windows builds to match Unix builds